### PR TITLE
Update screenly-cli.rb

### DIFF
--- a/Formula/screenly-cli.rb
+++ b/Formula/screenly-cli.rb
@@ -2,8 +2,8 @@ class ScreenlyCli < Formula
   desc "Command line interface is intended for quick interaction with Screenly through terminal."
   homepage "https://github.com/Screenly/cli"
   url "https://github.com/Screenly/cli.git",
-      tag: "v0.2.5"
-  version "v0.2.5"
+      tag: "v0.2.6"
+  version "v0.2.6"
   license "MIT"
 
   depends_on "rust" => :build


### PR DESCRIPTION
0.2.6 cli Changes:

- Delete missing in the yaml file settings.
- Entrypoint now pushed to installation instead of version.
- Name of the installation from cli is now equal to app name instead of generic name when new app is created.