### PR TITLE
Bump version to 26.8.0

### DIFF
--- a/Formula/screenly-cli.rb
+++ b/Formula/screenly-cli.rb
@@ -2,8 +2,8 @@ class ScreenlyCli < Formula
   desc "Command line interface is intended for quick interaction with Screenly through terminal."
   homepage "https://github.com/Screenly/cli"
   url "https://github.com/Screenly/cli.git",
-      tag: "v1.1.1"
-  version "v1.1.1"
+      tag: "v26.8.0"
+  version "v26.8.0"
   license "MIT"
 
   depends_on "rust" => :build


### PR DESCRIPTION
This PR depends on [Screenly/cli#313](https://github.com/Screenly/cli/pull/313) being merged and `v26.8.0` being tagged/released first.